### PR TITLE
fix volume not found docker inside docker

### DIFF
--- a/jenkins/docker-compose.yml
+++ b/jenkins/docker-compose.yml
@@ -13,6 +13,9 @@ services:
     volumes:
       - 'jenkins_data:/bitnami'
       - '/var/run/docker.sock:/var/run/docker.sock'
+      - 'jenkins_home:/opt/'
 volumes:
   jenkins_data:
+    driver: local
+  jenkins_home:
     driver: local


### PR DESCRIPTION
fix this issue https://github.com/eldada/jenkins-in-kubernetes/issues/2 but in case of using jenkins in docker and docker pipeline