### PR TITLE
fix Jenkins Volume

### DIFF
--- a/jenkins/docker-compose.yml
+++ b/jenkins/docker-compose.yml
@@ -14,7 +14,7 @@ services:
     volumes:
       - 'jenkins_data:/bitnami'
       - '/var/run/docker.sock:/var/run/docker.sock'
-      - 'jenkins_home:/opt/'
+      - 'jenkins_home:/var/jenkins_home'
 volumes:
   jenkins_data:
     driver: local


### PR DESCRIPTION
Jenkins stocke son workspace dans /var/jenkins_home et non dans /opt,
Pareil, il ya rien dans le répertoire /bitnami qui est monté en volume ...