### PR TITLE
add stack for java-cicd

### DIFF
--- a/vagrant/java-cicd/Vagrantfile
+++ b/vagrant/java-cicd/Vagrantfile
@@ -1,0 +1,18 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+Vagrant.configure("2") do |config|
+  config.vm.define "jenkins" do |jenkins|
+    jenkins.vm.box = "geerlingguy/centos7"
+    jenkins.vm.network "private_network", type: "dhcp"
+    jenkins.vm.hostname = "jenkins"
+    jenkins.vm.provider "virtualbox" do |v|
+      v.name = "jenkins"
+      v.memory = 2048
+      v.cpus = 2
+    end
+    jenkins.vm.provision :shell do |shell|
+      shell.path = "install_jenkins.sh"
+    end
+  end
+end

--- a/vagrant/java-cicd/Vagrantfile
+++ b/vagrant/java-cicd/Vagrantfile
@@ -2,17 +2,17 @@
 # vi: set ft=ruby :
 
 Vagrant.configure("2") do |config|
-  config.vm.define "jenkins" do |jenkins|
-    jenkins.vm.box = "geerlingguy/centos7"
-    jenkins.vm.network "private_network", type: "dhcp"
-    jenkins.vm.hostname = "jenkins"
-    jenkins.vm.provider "virtualbox" do |v|
-      v.name = "jenkins"
-      v.memory = 2048
-      v.cpus = 2
-    end
-    jenkins.vm.provision :shell do |shell|
-      shell.path = "install_jenkins.sh"
+    config.vm.define "java" do |java|
+      java.vm.box = "geerlingguy/centos7"
+      java.vm.network "private_network", type: "dhcp"
+      java.vm.hostname = "java"
+      java.vm.provider "virtualbox" do |v|
+        v.name = "java"
+        v.memory = 16384
+        v.cpus = 4
+      end
+      java .vm.provision :shell do |shell|
+        shell.path = "install_java.sh"
+      end
     end
   end
-end

--- a/vagrant/java-cicd/install_java.sh
+++ b/vagrant/java-cicd/install_java.sh
@@ -1,0 +1,35 @@
+#!/bin/sh
+sudo yum -y update
+
+# Install docker
+curl -fsSL https://get.docker.com -o get-docker.sh
+sh get-docker.sh
+usermod -aG docker vagrant
+systemctl enable docker
+systemctl start docker
+yum install -y sshpass
+
+# Install epel-release,firefox,  git, java
+yum -y install epel-release git java-11-openjdk-devel
+
+
+# Installation de maven 3.8
+cd /usr/local/src/
+yum install wget -y
+wget https://downloads.apache.org/maven/maven-3/3.8.5/binaries/apache-maven-3.8.5-bin.tar.gz 
+tar -xvf apache-maven-3.8.5-bin.tar.gz 
+mv apache-maven-3.8.5 /usr/local/maven/
+echo -e "# Apache Maven Environment Variables\n# MAVEN_HOME for Maven 1 - M2_HOME for Maven 2\nexport M2_HOME=/usr/local/maven\nexport PATH=${M2_HOME}/bin:${PATH}" > /etc/profile.d/maven.sh
+chmod +x /etc/profile.d/maven.sh
+source /etc/profile.d/maven.sh
+
+
+
+# Configure docker host requirements for sonar container
+sysctl -w vm.max_map_count=524288
+sysctl -w fs.file-max=131072
+ulimit -n 131072
+ulimit -u 8192
+
+echo "For this Stack, you will use $(ip -f inet addr show enp0s8 | sed -En -e 's/.*inet ([0-9.]+).*/\1/p') IP Address"
+echo -e "Connect through ssh on the VM and then run \n 'sudo alternatives --config java' and then press '1' + Enter. \n Also, run 'sudo alternatives --config javac', and then press '1' + Enter. \n The second time is not a repetition, there is 'c' after 'java'"


### PR DESCRIPTION
Stack vagrant pour le cour de cicd pour devops
Ce cours requiert une VM robuste de minimum 16 Go de RAM, uniquement à cause de SonarQube.
Le script de provisioning peut être récupéré pour lancer en user-data sur une VM Amazone.